### PR TITLE
feature(backend): parallelize execution and chunk extraction data into S3

### DIFF
--- a/cdk/lambda-functions/batch-generator/index.py
+++ b/cdk/lambda-functions/batch-generator/index.py
@@ -1,0 +1,52 @@
+import json
+import os
+import boto3
+import urllib.parse
+import tempfile
+from pdf2image import pdfinfo_from_path
+
+s3 = boto3.client('s3')
+BATCH_SIZE = int(os.environ.get('BATCH_SIZE', '1'))
+
+def handler(event, context):
+    # --- 1) Normalize bucket name ---
+    raw_bucket = event.get('detail', {}).get('bucket')
+    if isinstance(raw_bucket, dict):
+        bucket = raw_bucket.get('name')
+    else:
+        bucket = raw_bucket
+
+    # --- 2) Normalize object key ---
+    raw_obj = event.get('detail', {}).get('object')
+    if isinstance(raw_obj, dict):
+        key = raw_obj.get('key')
+    else:
+        key = raw_obj
+
+    if not bucket or not key:
+        raise RuntimeError(f"Cannot find S3 bucket/key in event: {json.dumps(event)}")
+
+    # URL‑decode just in case
+    key = urllib.parse.unquote_plus(key)
+
+    # Use a temp dir that’s auto‑cleaned at the end of the with‑block
+    with tempfile.TemporaryDirectory(dir='/tmp') as tmpdir:
+        # --- 3) Download PDF into temp dir ---
+        local_filename = os.path.basename(key)
+        local_path = os.path.join(tmpdir, local_filename)
+        s3.download_file(bucket, key, local_path)
+
+        # --- 4) Count pages ---
+        info = pdfinfo_from_path(local_path)
+        total_pages = int(info.get("Pages", 0))
+
+        # --- 5) Build batchRanges ---
+        batches = []
+        p = 1
+        while p <= total_pages:
+            end = min(p + BATCH_SIZE - 1, total_pages)
+            batches.append({"start": p, "end": end})
+            p = end + 1
+
+    # --- 6) Return to Step Functions ---
+    return {"batchRanges": batches}

--- a/cdk/lambda-functions/bedrock-extract/index.py
+++ b/cdk/lambda-functions/bedrock-extract/index.py
@@ -1,20 +1,21 @@
 import json
 import boto3
 import os
-import base64
 import io
 import urllib.parse
-from pdf2image import convert_from_path
-from datetime import datetime, timezone
 import re
-
+import gc
+from datetime import datetime, timezone
+from pdf2image import pdfinfo_from_path, convert_from_path
+from PIL import Image, ImageOps
 # Initialize AWS clients outside the handler for reuse
 s3 = boto3.client('s3')
 bedrock_runtime = boto3.client(service_name='bedrock-runtime')
 dynamodb_client = boto3.client('dynamodb')
-jobs_table_name = os.environ.get('JOBS_TABLE_NAME')
-BATCH_SIZE = 3
-
+JOBS_TABLE = os.environ.get('JOBS_TABLE_NAME')
+BATCH_SIZE = 1
+DPI = 150
+MAX_DIMENSION = 8000
 
 def get_extraction_prompt(document_type, insurance_type, page_numbers, previous_analysis_json="{}"):
     """Get the appropriate extraction prompt for a batch of pages, considering previous analysis."""
@@ -73,265 +74,134 @@ Here come the images for pages {page_numbers}:
 
 def lambda_handler(event, context):
     print("Received event:", json.dumps(event))
-    
-    # Initialize variables
-    bucket = None
-    key = None 
-    encoded_key = None 
-    download_path = None
-    document_type = None
-    all_extracted_data = {}
-    extraction_result = {"status": "ERROR", "message": "Processing not completed", "data": {}}
-    job_id = None
-    
+    batch_data = {}        # make sure this exists no matter what
+    # --- 1) Parse event ---
     try:
-        # --- Step 1: Extract input parameters from the event ---
+        bucket = event['detail']['bucket']['name']
+        key = urllib.parse.unquote_plus(event['detail']['object']['key'])
+        job_id = event['classification']['jobId']
+        doc_type = event['classification']['classification']
+        ins_type = event['classification']['insuranceType']
+    except Exception as e:
+        return {"status": "ERROR", "message": f"Invalid event format: {e}"}
+
+    # --- 2) Mark EXTRACTING in DynamoDB ---
+    if job_id and JOBS_TABLE:
         try:
-            bucket = event['detail']['bucket']['name']
-            encoded_key = event['detail']['object']['key'] 
-            key = urllib.parse.unquote_plus(encoded_key)
-            print(f"Event: {event}")
-            job_id = event.get('classification').get('jobId')
-            document_type = event.get('classification').get('classification')
-            insurance_type = event.get('classification').get('insuranceType')
-            print(f"Job ID: {job_id}")
-            print(f"Document type: {document_type}")
-            print(f"Insurance type: {insurance_type}")
-                
-            if not bucket or not key:
-                raise ValueError("Missing S3 bucket or key in input event")
+            now = datetime.now(timezone.utc).isoformat()
+            dynamodb_client.update_item(
+                TableName=JOBS_TABLE,
+                Key={'jobId': {'S': job_id}},
+                UpdateExpression="SET #s = :s, #t = :t",
+                ExpressionAttributeNames={'#s': 'status', '#t': 'extractionStartTimestamp'},
+                ExpressionAttributeValues={':s': {'S': 'EXTRACTING'}, ':t': {'S': now}},
+            )
+        except Exception:
+            pass
 
-            print(f"Original encoded key: {encoded_key}")
-            print(f"Decoded key for S3: {key}")
-            print(f"Processing s3://{bucket}/{key} with document type: {document_type}")
-            
-            safe_filename = os.path.basename(key) 
-            download_path = f'/tmp/{safe_filename}'
-            print(f"Download path set to: {download_path}")
+    # --- 3) Download PDF locally ---
+    local_path = f"/tmp/{os.path.basename(key)}"
+    try:
+        s3.download_file(bucket, key, local_path)
+    except Exception as e:
+        return {"status": "ERROR", "message": f"S3 download failed: {e}"}
 
+    # --- 4) Read total pages from PDF ---
+    try:
+        info = pdfinfo_from_path(local_path)
+        total_pages_full = int(info.get("Pages", 0))
+    except Exception as e:
+        return {"status": "ERROR", "message": f"Could not read PDF info: {e}"}
 
-            # --- Update DynamoDB status to EXTRACTING ---
-            if job_id and jobs_table_name:
-                try:
-                    timestamp_now = datetime.now(timezone.utc).isoformat()
-                    dynamodb_client.update_item(
-                        TableName=jobs_table_name,
-                        Key={'jobId': {'S': job_id}},
-                        UpdateExpression="SET #status_attr = :status_val, #extractStartTs = :extractStartTsVal",
-                        ExpressionAttributeNames={
-                            '#status_attr': 'status',
-                            '#extractStartTs': 'extractionStartTimestamp'
-                        },
-                        ExpressionAttributeValues={
-                            ':status_val': {'S': 'EXTRACTING'},
-                            ':extractStartTsVal': {'S': timestamp_now}
-                        }
-                    )
-                    print(f"Updated job {job_id} status to EXTRACTING")
-                except Exception as ddb_e:
-                    print(f"Error updating DynamoDB status for job {job_id}: {str(ddb_e)}")
+    # --- 5) Determine page batches (or single range) ---
+    page_range = event.get('pages')
+    page_batches = []
+    if page_range:
+        # single batch from SF Map
+        first_page = page_range.get('start', 1)
+        last_page = page_range.get('end', first_page)
+        page_batches.append((first_page, last_page))
+    else:
+        # full-document batching
+        page = 1
+        while page <= total_pages_full:
+            last = min(page + BATCH_SIZE - 1, total_pages_full)
+            page_batches.append((page, last))
+            page = last + 1
 
-        except (KeyError, ValueError, TypeError) as e:
-            print(f"Error extracting input parameters: {e}")
-            extraction_result["message"] = f"Error extracting input parameters: {str(e)}"
-            return extraction_result
-        print(f"Successfully extracted input parameters. Bucket: {bucket}, Key: {key}, DocType: {document_type}")
+    all_data = {}
 
-        # --- Step 2: Download PDF from S3 ---
+    # --- 6) Process each batch in sequence (Step Functions will parallelize via Map) ---
+    for (first, last) in page_batches:
+        # Convert only this batch to images
         try:
-            s3.download_file(bucket, key, download_path)
-            print(f"Successfully downloaded to {download_path}")
+            imgs = convert_from_path(
+                local_path,
+                dpi=DPI,
+                fmt='JPEG',
+                first_page=first,
+                last_page=last
+            )
         except Exception as e:
-            print(f"Error downloading from S3: {e}")
-            extraction_result["message"] = f"Error downloading from S3: {str(e)}"
-            return extraction_result
-        print(f"Successfully downloaded PDF from S3 to {download_path}")
+            return {"status": "ERROR", "message": f"PDF→image conversion failed for pages {first}–{last}: {e}"}
 
-        # --- Step 3: Convert PDF pages to images ---
+        # Build prompt & payload
+        prompt = get_extraction_prompt(doc_type, ins_type, list(range(first, last+1)), json.dumps(all_data, indent=2))
+        messages = [{"text": prompt}]
+        for idx, img in enumerate(imgs, start=first):
+            img = img.convert("L")
+            img = ImageOps.crop(img, border=50)
+            w, h = img.size
+            if max(w, h) > MAX_DIMENSION:
+                scale = MAX_DIMENSION / float(max(w, h))
+                img = img.resize((int(w*scale), int(h*scale)), Image.LANCZOS)
+            buf = io.BytesIO()
+            img.save(buf, format="JPEG", quality=60, optimize=True)
+            payload_bytes = buf.getvalue()
+            buf.close()
+            messages.append({"text": f"--- Image for Page {idx} ---"})
+            messages.append({"image": {"format": "jpeg", "source": {"bytes": payload_bytes}}})
+
+        # Call Bedrock Converse API
         try:
-           
-            print(f"Attempting to convert PDF to images.")
-            images = convert_from_path(download_path, dpi=200, fmt='JPEG', first_page=1)
-            print(f"Successfully converted {len(images)} pages to images.")
-            
-            if not images:
-                raise ValueError("No images were extracted from the PDF")
-                
+            resp = bedrock_runtime.converse(
+                modelId=os.environ.get('BEDROCK_MODEL_ID'),
+                messages=[{"role": "user", "content": messages}],
+                inferenceConfig={"maxTokens": 4096, "temperature": 0.0}
+            )
         except Exception as e:
-            print(f"Error converting PDF to images: {e}")
-            extraction_result["message"] = f"Error converting PDF to images: {str(e)}"
-            return extraction_result
-        
-        # Prepare raw image bytes for Bedrock
-        print(f"Starting image processing loop to convert to bytes.")
-        image_byte_list = [] 
-        for i, img in enumerate(images):
-            buffer = io.BytesIO()
-            img.save(buffer, format="JPEG")
-            raw_bytes = buffer.getvalue()
-            image_byte_list.append(raw_bytes)
-        print(f"Finished image processing loop. {len(image_byte_list)} images converted to bytes.")
+            return {"status": "ERROR", "message": f"Bedrock call failed for pages {first}–{last}: {e}"}
 
-        # --- Step 4 & 5: Batch process pages, create prompt, call Bedrock ---
-        all_extracted_data = {}
-        page_idx = 0
-        total_pages = len(image_byte_list)
-        insurance_type = event.get('classification', {}).get('insuranceType', 'property_casualty')
-
-        while page_idx < total_pages:
-            batch_images = image_byte_list[page_idx : page_idx + BATCH_SIZE]
-            batch_page_nums = list(range(page_idx + 1, page_idx + 1 + len(batch_images)))
-            
-            print(f"Processing batch for pages: {batch_page_nums}")
-
-            # Get the stateful extraction prompt
-            previous_analysis_json = json.dumps(all_extracted_data, indent=2)
-            prompt_text = get_extraction_prompt(document_type, insurance_type, batch_page_nums, previous_analysis_json)
-
-            # Prepare the content for the user message in Converse API
-            converse_user_message_content = [{"text": prompt_text}]
-            for i, raw_image_data in enumerate(batch_images):
-                page_number = batch_page_nums[i]
-                # Adding a text marker for which page is which could be helpful for the model
-                converse_user_message_content.append({"text": f"--- Image for Page {page_number} ---"})
-                converse_user_message_content.append({
-                    "image": {
-                        "format": "jpeg",
-                        "source": {"bytes": raw_image_data}
-                    }
-                })
-
-            # Call Bedrock with Claude 3 using the Converse API
+        # Extract JSON
+        output = resp.get('output', {}).get('message', {})
+        text = (output.get('content') or [{}])[0].get('text', '')
+        match = (re.search(r'```json\s*([\s\S]*?)```', text, re.DOTALL)
+                 or re.search(r'(\{[\s\S]*\})', text, re.DOTALL))
+        if match:
             try:
-                model_id = os.environ.get('BEDROCK_MODEL_ID', 'anthropic.claude-3-sonnet-20240229-v1:0')
-                
-                print(f"Preparing to call Bedrock Converse API with model {model_id} for pages {batch_page_nums}.")
-                response = bedrock_runtime.converse(
-                    modelId=model_id,
-                    messages=[{
-                        "role": "user",
-                        "content": converse_user_message_content
-                    }],
-                    inferenceConfig={
-                        "maxTokens": 4096,
-                        "temperature": 0.0
-                    }
-                )
-                print(f"Received raw response from Bedrock Converse API for pages {batch_page_nums}.")
-                
-            except Exception as e:
-                print(f"Error calling Bedrock for batch {batch_page_nums}: {e}")
-                extraction_result["message"] = f"Error calling Bedrock: {str(e)}"
-                return extraction_result
+                batch_data = json.loads(match.group(1))
+                for k, pages_list in batch_data.items():
+                    all_data.setdefault(k, []).extend(pages_list or [])
+            except Exception:
+                pass
 
-            # --- Step 6: Parse response and merge results ---
-            output_message = response.get('output', {}).get('message', {})
-            if not output_message or not output_message.get('content'):
-                print(f"Bedrock response missing 'output' or 'content' field for batch {batch_page_nums}. Response: {json.dumps(response)}")
-                page_idx += BATCH_SIZE
-                continue
-            
-            assistant_response_text = output_message.get('content', [])[0]['text']
-            print(f"Successfully extracted assistant response text. Length: {len(assistant_response_text)}")
+        # Cleanup
+        del imgs
+        gc.collect()
 
-            try:
-                print(f"Attempting to parse JSON from Bedrock response...")
-                json_str = assistant_response_text
-                # Clean potential markdown ```json ... ```
-                json_match = re.search(r'```json\s*([\s\S]*?)\s*```', assistant_response_text, re.DOTALL)
-                if json_match:
-                    json_str = json_match.group(1)
-                else:
-                    # Last resort: find anything that looks like a JSON object
-                    json_match = re.search(r'(\{[\s\S]*\})', assistant_response_text, re.DOTALL)
-                    if json_match:
-                        json_str = json_match.group(1)
-                
-                batch_data = json.loads(json_str)
+    # --- 8) Cleanup & return ---
+    try:
+        os.remove(local_path)
+    except OSError:
+        pass
 
-                # --- Merge batch_data into all_extracted_data ---
-                print("Merging batch data into overall results...")
-                for doc_type, pages_list in batch_data.items():
-                    if not isinstance(pages_list, list):
-                        print(f"Warning: Value for key '{doc_type}' is not a list, skipping.")
-                        continue
-
-                    if doc_type in all_extracted_data:
-                        all_extracted_data[doc_type].extend(pages_list)
-                    else:
-                        all_extracted_data[doc_type] = pages_list
-                print("Merge complete for this batch.")
-
-            except (json.JSONDecodeError, ValueError) as e:
-                print(f"Error parsing JSON from response for batch {batch_page_nums}: {e}")
-                print(f"Raw response was: {assistant_response_text}")
-            
-            # Move to the next batch
-            page_idx += BATCH_SIZE
-
-        print(f"All extracted data: {all_extracted_data}")
-
-        # --- DynamoDB Update Logic --- 
-        if job_id and jobs_table_name and all_extracted_data:
-            try:
-                timestamp_now = datetime.now(timezone.utc).isoformat()
-                
-                update_expression_parts = [
-                    "SET #docType = :docType", 
-                    "#extDataJsonStr = :extDataJsonStrVal", 
-                    "#extTimestamp = :extTimestampVal"
-                ]
-                expression_attribute_names = {
-                    '#docType': 'documentType',
-                    '#extDataJsonStr': 'extractedDataJsonStr', 
-                    '#extTimestamp': 'extractionTimestamp'
-                }
-                expression_attribute_values = {
-                    ':docType': {'S': document_type},
-                    ':extDataJsonStrVal': {'S': json.dumps(all_extracted_data)},
-                    ':extTimestampVal': {'S': timestamp_now}
-                }
-
-                inferred_insurance_type = None
-                if document_type in ["COMMERCIAL_PROPERTY_APPLICATION", "FINANCIAL_STATEMENT"]:
-                    inferred_insurance_type = "property_casualty"
-                elif document_type in ["MEDICAL_REPORT"]:
-                    inferred_insurance_type = "life"
-                
-                if inferred_insurance_type:
-                    update_expression_parts.append("#insType = :insTypeVal")
-                    expression_attribute_names['#insType'] = 'insuranceType'
-                    expression_attribute_values[':insTypeVal'] = {'S': inferred_insurance_type}
-
-                dynamodb_client.update_item(
-                    TableName=jobs_table_name,
-                    Key={'jobId': {'S': job_id}},
-                    UpdateExpression=', '.join(update_expression_parts),
-                    ExpressionAttributeNames=expression_attribute_names,
-                    ExpressionAttributeValues=expression_attribute_values
-                )
-                print(f"Successfully updated job {job_id} in DynamoDB with extraction results.")
-            except Exception as ddb_e:
-                print(f"Error updating DynamoDB for job {job_id}: {str(ddb_e)}. Proceeding without DDB update.")
-        else:
-            print("Skipping DynamoDB update: jobId not parsed, table name missing, or no extracted data.")
-
-        # Return the extracted data
-        extraction_result = {
-            "status": "SUCCESS",
-            "message": f"Successfully extracted data from {document_type}",
-            "document_type": document_type,
-            "data": all_extracted_data
-        }
-
-    finally:
-        # Clean up temporary files
-        if download_path and os.path.exists(download_path):
-            try:
-                os.remove(download_path)
-                print(f"Cleaned up temporary file: {download_path}")
-            except Exception as e:
-                print(f"Error during cleanup: {e}")
-
-    print(f"Final extraction result: {json.dumps(extraction_result)}")
-    return extraction_result
+    chunk_key = f"{job_id}/extracted/{first_page}-{last_page}.json"
+    s3.put_object(
+    Bucket=os.environ['EXTRACTION_BUCKET'],
+    Key=chunk_key,
+    Body=json.dumps(batch_data),
+    )
+    return {
+    "pages": {"start": first_page, "end": last_page},
+    "chunkS3Key": chunk_key
+    }

--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -58,6 +58,37 @@ export class CdkStack extends cdk.Stack {
       ],
     });
 
+    // Create S3 bucket to store extraction chunks
+    const extractionBucket = new s3.Bucket(this, 'ExtractionBucket', {
+      bucketName: cdk.Fn.join('-', ['ai-underwriting', cdk.Aws.ACCOUNT_ID, 'extraction-chunks']),
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      removalPolicy: cdk.RemovalPolicy.DESTROY, // For development - change for production
+      autoDeleteObjects: true,
+      versioned: true,
+      eventBridgeEnabled: true,
+      cors: [
+        {
+          allowedMethods: [
+            s3.HttpMethods.PUT,
+            s3.HttpMethods.POST,
+            s3.HttpMethods.GET,
+            s3.HttpMethods.DELETE,
+            s3.HttpMethods.HEAD,
+          ],
+          allowedOrigins: ['*'], // This will be replaced by CloudFront domain in production
+          allowedHeaders: ['*'],
+          exposedHeaders: ['ETag'],
+          maxAge: 3000
+        },
+      ],
+      lifecycleRules: [
+        {
+          expiration: cdk.Duration.days(30), // Auto-delete files after 30 days
+        },
+      ],
+    });
+
+
     // Create S3 bucket for mock output files
     const mockOutputBucket = new s3.Bucket(this, 'MockOutputBucket', {
       bucketName: cdk.Fn.join('-', ['ai-underwriting', cdk.Aws.ACCOUNT_ID, 'mock-output']),
@@ -68,6 +99,12 @@ export class CdkStack extends cdk.Stack {
     });
 
     // Create Lambda Layers
+    const pillowLayer = new lambda.LayerVersion(this, 'PillowLayer', {
+      code: lambda.Code.fromAsset('lambda-layers/pillow-py312.zip'),
+      compatibleRuntimes: [lambda.Runtime.PYTHON_3_12],
+      description: 'Image processing libaries for downsizing',
+    });
+
     const pdfProcessingLayer = new lambda.LayerVersion(this, 'PdfProcessingLayer', {
       code: lambda.Code.fromAsset('lambda-layers/pdf-tools-py312.zip'),
       compatibleRuntimes: [lambda.Runtime.PYTHON_3_12],
@@ -120,6 +157,8 @@ export class CdkStack extends cdk.Stack {
       resources: [
         documentBucket.arnForObjects('*'),
         documentBucket.bucketArn,
+        extractionBucket.arnForObjects('*'),
+        extractionBucket.bucketArn,
         mockOutputBucket.arnForObjects('*'),
         mockOutputBucket.bucketArn
       ],
@@ -143,6 +182,7 @@ export class CdkStack extends cdk.Stack {
       memorySize: 256,
       environment: {
         DOCUMENT_BUCKET: documentBucket.bucketName,
+        EXTRACTION_BUCKET: extractionBucket.bucketName,
         JOBS_TABLE_NAME: jobsTable.tableName,
         // STATE_MACHINE_ARN will be added later
       },
@@ -164,7 +204,21 @@ export class CdkStack extends cdk.Stack {
       layers: [pdfProcessingLayer, boto3Layer],
     });
 
-    // 3. Bedrock Extract Lambda
+    // 3. Batch Page Lambda
+    const batchGeneratorLambda = new lambda.Function(this, 'BatchGeneratorLambda', {
+      functionName: 'ai-underwriting-batch-generator',
+      runtime: lambda.Runtime.PYTHON_3_12,
+      code: lambda.Code.fromAsset('lambda-functions/batch-generator'),
+      handler: 'index.handler',
+      timeout: cdk.Duration.minutes(1),
+      memorySize: 1024,
+      layers: [pdfProcessingLayer],
+      environment: {
+        BATCH_SIZE: '1',
+      },
+    });
+
+    // 4. Bedrock Extract Lambda
     const bedrockExtractLambda = new lambda.Function(this, 'BedrockExtractLambda', {
       functionName: 'ai-underwriting-bedrock-extract',
       runtime: lambda.Runtime.PYTHON_3_12,
@@ -176,26 +230,29 @@ export class CdkStack extends cdk.Stack {
         BEDROCK_MODEL_ID: 'us.anthropic.claude-3-7-sonnet-20250219-v1:0',
         JOBS_TABLE_NAME: jobsTable.tableName,
         MAX_PAGES_FOR_EXTRACTION: '5',
+        EXTRACTION_BUCKET: extractionBucket.bucketName
       },
-      layers: [pdfProcessingLayer, boto3Layer],
+      layers: [pillowLayer, pdfProcessingLayer, boto3Layer],
     });
-    
-    // 4. Analyze Lambda
+
+    // 5. Analyze Lambda
     const analyzeLambda = new lambda.Function(this, 'AnalyzeLambda', {
       functionName: 'ai-underwriting-analyze',
       runtime: lambda.Runtime.PYTHON_3_12,
       code: lambda.Code.fromAsset('lambda-functions/analyze'),
       handler: 'index.lambda_handler',
       timeout: cdk.Duration.minutes(5),
+      ephemeralStorageSize: cdk.Size.gibibytes(2),
       memorySize: 512,
       environment: {
         BEDROCK_ANALYSIS_MODEL_ID: 'us.anthropic.claude-3-7-sonnet-20250219-v1:0',
         JOBS_TABLE_NAME: jobsTable.tableName,
+        EXTRACTION_BUCKET: extractionBucket.bucketName
       },
       layers: [boto3Layer],
     });
 
-    // 5. Act Lambda
+    // 6. Act Lambda
     const actLambda = new lambda.Function(this, 'ActLambda', {
       functionName: 'ai-underwriting-act',
       runtime: lambda.Runtime.PYTHON_3_12,
@@ -210,7 +267,7 @@ export class CdkStack extends cdk.Stack {
       layers: [strandsSDKLayer, boto3Layer],
     });
 
-    // 6. Chat Lambda
+    // 7. Chat Lambda
     const chatLambda = new lambda.Function(this, 'ChatLambda', {
       functionName: 'ai-underwriting-chat',
       runtime: lambda.Runtime.PYTHON_3_12,
@@ -233,12 +290,17 @@ export class CdkStack extends cdk.Stack {
     classifyLambda.addToRolePolicy(dynamodbPolicyStatement);
     classifyLambda.addToRolePolicy(s3PolicyStatement);
 
+    batchGeneratorLambda.addToRolePolicy(s3PolicyStatement);
+    batchGeneratorLambda.addToRolePolicy(dynamodbPolicyStatement);
+    batchGeneratorLambda.addToRolePolicy(bedrockPolicyStatement);
+
     bedrockExtractLambda.addToRolePolicy(bedrockPolicyStatement);
     bedrockExtractLambda.addToRolePolicy(dynamodbPolicyStatement);
     bedrockExtractLambda.addToRolePolicy(s3PolicyStatement);
 
     analyzeLambda.addToRolePolicy(bedrockPolicyStatement);
     analyzeLambda.addToRolePolicy(dynamodbPolicyStatement);
+    analyzeLambda.addToRolePolicy(s3PolicyStatement);
 
     actLambda.addToRolePolicy(bedrockPolicyStatement);
     actLambda.addToRolePolicy(dynamodbPolicyStatement);
@@ -254,13 +316,42 @@ export class CdkStack extends cdk.Stack {
       payloadResponseOnly: true,
     });
 
-    // Define extraction steps
-    const bedrockExtractStep = new stepfunctionsTasks.LambdaInvoke(this, 'ExtractWithBedrock', {
-      lambdaFunction: bedrockExtractLambda,
-      resultPath: '$.extraction',
+    const generateBatchesStep = new stepfunctionsTasks.LambdaInvoke(this, 'GenerateBatches', {
+      lambdaFunction: batchGeneratorLambda,
+      // pass through the bucket/key and classification info
+      payload: stepfunctions.TaskInput.fromObject({
+        detail: {
+          bucket: stepfunctions.JsonPath.stringAt('$.detail.bucket.name'),
+          object: { key: stepfunctions.JsonPath.stringAt('$.detail.object.key') }
+        },
+        classification: stepfunctions.JsonPath.stringAt('$.classification')
+      }),
+      resultPath: '$.batches',
       payloadResponseOnly: true,
     });
 
+    const parallelExtract = new stepfunctions.Map(this, 'ParallelExtraction', {
+      itemsPath: '$.batches.batchRanges',
+      resultPath: '$.extractionResults',
+      maxConcurrency: 4,
+      parameters: {
+        'detail.$': '$.detail',
+        'classification.$': '$.classification',
+        'pages.$': '$$.Map.Item.Value',
+      }
+    });
+
+    const extractTask = new stepfunctionsTasks.LambdaInvoke(this, 'ExtractWithBedrock', {
+      lambdaFunction: bedrockExtractLambda,
+      payloadResponseOnly: true,
+      resultSelector: {
+        'pages.$':  '$.pages',
+        'chunkS3Key.$': '$.chunkS3Key'
+      },
+      resultPath: '$',
+    });
+
+    parallelExtract.itemProcessor(extractTask);
 
     const analyzeStep = new stepfunctionsTasks.LambdaInvoke(this, 'AnalyzeData', {
       lambdaFunction: analyzeLambda,
@@ -273,12 +364,12 @@ export class CdkStack extends cdk.Stack {
       payloadResponseOnly: true,
     });
 
-    classifyStep.next(bedrockExtractStep);
+    classifyStep
+      .next(generateBatchesStep)
+      .next(parallelExtract)
+      .next(analyzeStep)
+      .next(actStep);
       
-    bedrockExtractStep.next(analyzeStep);
-    
-    analyzeStep.next(actStep);
-
     // Create a log group for the state machine
     const logGroup = new logs.LogGroup(this, 'DocumentProcessingLogGroup', {
       retention: logs.RetentionDays.ONE_WEEK,
@@ -288,7 +379,7 @@ export class CdkStack extends cdk.Stack {
     const stateMachine = new stepfunctions.StateMachine(this, 'DocumentProcessingWorkflow', {
       stateMachineName: 'ai-underwriting-workflow',
       definition: classifyStep,
-      timeout: cdk.Duration.minutes(30),
+      timeout: cdk.Duration.minutes(60),
       // Add logging configuration
       logs: {
         destination: logGroup,
@@ -496,6 +587,16 @@ export class CdkStack extends cdk.Stack {
       id: 'AwsSolutions-S10',
       reason: 'S3 bucket or bucket policy does not require SSL requests. This is for development purposes. Will be enforced in production.',
     }]);
+    NagSuppressions.addResourceSuppressions(extractionBucket, [{
+      id: 'AwsSolutions-S3-1',
+      reason: 'Using wildcard for simplicity in development. Will be restricted in production.',
+    },{
+      id: 'AwsSolutions-S1',
+      reason: 'S3 bucket server access logging is not enabled for development. Will be enabled in production.',
+    },{
+      id: 'AwsSolutions-S10',
+      reason: 'S3 bucket or bucket policy does not require SSL requests. This is for development purposes. Will be enforced in production.',
+    }]);
     NagSuppressions.addResourceSuppressions(websiteBucket, [{
       id: 'AwsSolutions-S3-1',
       reason: 'Using wildcard for simplicity in development. Will be restricted in production.',
@@ -509,6 +610,10 @@ export class CdkStack extends cdk.Stack {
     
     // Add specific suppression for DocumentBucket Policy Resource
     NagSuppressions.addResourceSuppressionsByPath(this, '/AWS-GENAI-UW-DEMO/DocumentBucket/Policy/Resource', [{
+      id: 'AwsSolutions-S10',
+      reason: 'S3 bucket policy does not require SSL requests. This is for development purposes. Will be enforced in production.',
+    }]);
+    NagSuppressions.addResourceSuppressionsByPath(this, '/AWS-GENAI-UW-DEMO/ExtractionBucket/Policy/Resource', [{
       id: 'AwsSolutions-S10',
       reason: 'S3 bucket policy does not require SSL requests. This is for development purposes. Will be enforced in production.',
     }]);
@@ -594,6 +699,12 @@ export class CdkStack extends cdk.Stack {
       id: 'AwsSolutions-L1',
       reason: 'Using Python 3.12 which is the latest available runtime for this project.',
     }]);
+    NagSuppressions.addResourceSuppressionsByPath(this, '/AWS-GENAI-UW-DEMO/BatchGeneratorLambda/Resource', [
+      {
+        id: 'AwsSolutions-L1',
+        reason: 'Using Python 3.12 which is the latest available runtime for this project.',
+      },
+    ]);
 
     // Add suppression for Lambda functions using AWS managed policy
     NagSuppressions.addResourceSuppressionsByPath(this, '/AWS-GENAI-UW-DEMO/ClassifyLambda/ServiceRole/Resource', [{
@@ -616,6 +727,13 @@ export class CdkStack extends cdk.Stack {
       id: 'AwsSolutions-IAM4',
       reason: 'Lambda requires basic execution role for CloudWatch Logs access. This is acceptable for this demo.',
     }]);
+    NagSuppressions.addResourceSuppressionsByPath(this, '/AWS-GENAI-UW-DEMO/BatchGeneratorLambda/ServiceRole/Resource', [
+      {
+        id: 'AwsSolutions-IAM4',
+        reason: 'Lambda requires basic execution role for CloudWatch Logs access. This is acceptable for this demo.',
+      },
+    ]);
+
 
     // Add suppression for Lambda function DefaultPolicy wildcard permissions
     NagSuppressions.addResourceSuppressionsByPath(this, '/AWS-GENAI-UW-DEMO/ClassifyLambda/ServiceRole/DefaultPolicy/Resource', [{
@@ -638,6 +756,12 @@ export class CdkStack extends cdk.Stack {
       id: 'AwsSolutions-IAM5',
       reason: 'Lambda needs access to Bedrock and DynamoDB table indexes. This is acceptable for this demo.',
     }]);
+    NagSuppressions.addResourceSuppressionsByPath(this, '/AWS-GENAI-UW-DEMO/BatchGeneratorLambda/ServiceRole/DefaultPolicy/Resource', [
+      {
+        id: 'AwsSolutions-IAM5',
+        reason: 'Lambda needs access to Bedrock, DynamoDB table indexes and S3 bucket objects. This is acceptable for this demo.',
+      },
+    ]);
 
     // Add suppression for Step Function Role DefaultPolicy wildcard permissions
     NagSuppressions.addResourceSuppressionsByPath(this, '/AWS-GENAI-UW-DEMO/DocumentProcessingWorkflow/Role/DefaultPolicy/Resource', [{
@@ -751,6 +875,11 @@ export class CdkStack extends cdk.Stack {
 
     new cdk.CfnOutput(this, 'DocumentBucketName', {
       value: documentBucket.bucketName,
+      description: 'S3 Bucket for document uploads',
+    });
+
+    new cdk.CfnOutput(this, 'ExtractionBucketName', {
+      value: extractionBucket.bucketName,
       description: 'S3 Bucket for document uploads',
     });
 


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
- Refactor extraction step to operate in parallel by emitting discrete batchRanges (e.g., per-page ranges) via a batch generator, enabling independent work units.

- Chunk extracted document data into smaller pieces and persist each chunk immediately to S3 with its own key, instead of producing a monolithic payload.

- Populate extractionResults / batchRanges metadata with the generated start/end ranges so downstream steps can fetch and merge only needed chunks.

- Checks image size and downscales if the image is too large (8000 x 8000 px limit) for the Converse API.

This approach prevents oversized data from being passed downstream by splitting and storing extraction output incrementally (a workaround for States.DataLimitExceeded errors in Step Functions).

This process has been used for processing PDF documents with upwards of 250 pages. Using this setup, the main bottleneck is now the input into the Bedrock model inside the Analyze step.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.