### PR TITLE
Add single upload batch grouping

### DIFF
--- a/cdk/lambda-functions/api-handler/index.py
+++ b/cdk/lambda-functions/api-handler/index.py
@@ -266,8 +266,9 @@ def generate_upload_url(event):
         if not filename:
             return {'error': 'Missing filename in request'}
             
-        # Generate a unique job ID
+        # Generate a unique job ID and batch ID
         job_id = str(uuid.uuid4())
+        batch_id = str(uuid.uuid4())
         
         # Create S3 key with path structure
         s3_key = f"uploads/{job_id}/{filename}"
@@ -289,6 +290,7 @@ def generate_upload_url(event):
             TableName=JOBS_TABLE_NAME,
             Item={
                 'jobId': {'S': job_id},
+                'batchId': {'S': batch_id},
                 'status': {'S': 'CREATED'},
                 'uploadTimestamp': {'S': timestamp_now},
                 'originalFilename': {'S': filename},
@@ -299,6 +301,7 @@ def generate_upload_url(event):
         
         return {
             'jobId': job_id,
+            'batchId': batch_id,
             'uploadUrl': presigned_url,
             's3Key': s3_key,
             'status': 'CREATED',

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -517,7 +517,7 @@ function JobsList() {
 
   const groupJobsByBatch = (jobs: Job[]) => {
     const grouped = jobs.reduce((acc, job) => {
-      const batchId = job.batchId || 'no-batch';
+      const batchId = job.batchId; // All jobs now have batchId
       if (!acc[batchId]) {
         acc[batchId] = [];
       }
@@ -528,7 +528,6 @@ function JobsList() {
   };
 
   const getShortBatchId = (batchId: string) => {
-    if (batchId === 'no-batch') return 'Individual';
     return batchId.slice(-8);
   };
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Fixes a /jobs grouping issue when a single document was uploaded multiple times, it would be grouped together under an "Individual" BatchID.

- Add batchId generation to single file uploads
- Every upload now gets a unique batchId regardless of file count
- Single file uploads get individual batchId (prevents grouping with other singles as "Individual")
- Multi file uploads continue to share batchId (maintains batch grouping)
- Remove frontend fallback logic since all jobs now have batchId
- Preserves existing UI navigation behavior (single -> JobPage, batch -> Jobs)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
