### PR TITLE
Handle large docs. can remove the existing analyze and detect impairments

### DIFF
--- a/cdk/lambda-functions/aggregate-analysis/index.py
+++ b/cdk/lambda-functions/aggregate-analysis/index.py
@@ -1,0 +1,166 @@
+import json
+import boto3
+import os
+from datetime import datetime, timezone
+
+dynamodb_client = boto3.client('dynamodb')
+s3_client = boto3.client('s3')
+
+DB_TABLE = os.environ.get('JOBS_TABLE_NAME')
+TRACE_BUCKET = os.environ.get('TRACE_BUCKET')
+
+
+def aggregate_analysis_results(chunk_results: list) -> dict:
+    """
+    Merge multiple chunk analysis results into a single comprehensive result.
+    """
+    print(f"[aggregate] Aggregating {len(chunk_results)} chunk results")
+    
+    # Log any errors
+    error_chunks = [r for r in chunk_results if 'error' in r]
+    if error_chunks:
+        print(f"[aggregate] WARNING: {len(error_chunks)} chunks had errors:")
+        for err_chunk in error_chunks:
+            print(f"  - Chunk {err_chunk.get('chunkId', '?')}: {err_chunk.get('error', 'Unknown error')}")
+    
+    # Filter out error results
+    valid_results = [r for r in chunk_results if 'error' not in r]
+    if not valid_results:
+        return {'error': 'All chunks failed to analyze', 'failed_chunks': len(chunk_results)}
+    
+    print(f"[aggregate] {len(valid_results)} valid results out of {len(chunk_results)}")
+    
+    # Aggregate fields
+    aggregated = {
+        "overall_summary": " ".join([r.get("overall_summary", "") for r in valid_results]).strip(),
+        "identified_risks": [],
+        "discrepancies": [],
+        "medical_timeline": "",
+        "property_assessment": "",
+        "final_recommendation": "",
+        "missing_information": [],
+        "confidence_score": 0.0
+    }
+    
+    # Combine risks
+    for result in valid_results:
+        aggregated["identified_risks"].extend(result.get("identified_risks", []))
+    
+    # Combine discrepancies
+    for result in valid_results:
+        aggregated["discrepancies"].extend(result.get("discrepancies", []))
+    
+    # Combine missing information (deduplicate by item_description)
+    seen_missing = set()
+    for result in valid_results:
+        for item in result.get("missing_information", []):
+            desc = item.get("item_description", "")
+            if desc and desc not in seen_missing:
+                aggregated["missing_information"].append(item)
+                seen_missing.add(desc)
+    
+    # Combine medical timeline
+    timelines = [r.get("medical_timeline", "") for r in valid_results if r.get("medical_timeline") and r.get("medical_timeline") != "N/A"]
+    if timelines:
+        aggregated["medical_timeline"] = "\n\n".join(timelines)
+    else:
+        aggregated["medical_timeline"] = "N/A"
+    
+    # Combine property assessment
+    assessments = [r.get("property_assessment", "") for r in valid_results if r.get("property_assessment") and r.get("property_assessment") != "N/A"]
+    if assessments:
+        aggregated["property_assessment"] = "\n\n".join(assessments)
+    else:
+        aggregated["property_assessment"] = "N/A"
+    
+    # Combine recommendations
+    recommendations = [r.get("final_recommendation", "") for r in valid_results if r.get("final_recommendation")]
+    if recommendations:
+        aggregated["final_recommendation"] = "\n\n".join(recommendations)
+    
+    # Average confidence scores
+    scores = [r.get("confidence_score", 0.75) for r in valid_results if isinstance(r.get("confidence_score"), (int, float))]
+    if scores:
+        aggregated["confidence_score"] = sum(scores) / len(scores)
+    else:
+        aggregated["confidence_score"] = 0.75
+    
+    print(f"[aggregate] Aggregated: {len(aggregated['identified_risks'])} risks, {len(aggregated['discrepancies'])} discrepancies")
+    
+    return aggregated
+
+
+def lambda_handler(event, context):
+    print(f"[aggregate-analysis] Received event: {json.dumps(event)}")
+    
+    job_id = event.get('jobId')
+    chunk_results = event.get('chunkResults', [])
+    classification = event.get('classification', {})
+    document_type = classification.get('classification', 'Unknown')
+    
+    if not job_id:
+        return {'error': 'Missing jobId'}
+    
+    if not chunk_results:
+        return {'error': 'No chunk results to aggregate'}
+    
+    # Update status to ANALYZING
+    if DB_TABLE:
+        try:
+            from datetime import datetime, timezone
+            now = datetime.now(timezone.utc).isoformat()
+            dynamodb_client.update_item(
+                TableName=DB_TABLE,
+                Key={'jobId': {'S': job_id}},
+                UpdateExpression='SET #status = :s, lastUpdated = :t',
+                ExpressionAttributeNames={'#status': 'status'},
+                ExpressionAttributeValues={':s': {'S': 'ANALYZING'}, ':t': {'S': now}}
+            )
+            print(f"[aggregate-analysis] Updated status to ANALYZING for job {job_id}")
+        except Exception as e:
+            print(f"[aggregate-analysis] WARNING: Failed to update status: {e}")
+    
+    # --- 1) Aggregate results ---
+    aggregated_result = aggregate_analysis_results(chunk_results)
+    
+    if 'error' in aggregated_result:
+        return aggregated_result
+    
+    # --- 2) Store trace in S3 ---
+    if TRACE_BUCKET:
+        try:
+            trace_key = f"analysis-traces/{job_id}/aggregated-analysis.json"
+            s3_client.put_object(
+                Bucket=TRACE_BUCKET,
+                Key=trace_key,
+                Body=json.dumps(aggregated_result, indent=2),
+                ContentType='application/json'
+            )
+            print(f"[aggregate-analysis] Stored trace at s3://{TRACE_BUCKET}/{trace_key}")
+        except Exception as e:
+            print(f"[aggregate-analysis] Error storing trace: {e}")
+    
+    # --- 3) Persist to DynamoDB ---
+    if DB_TABLE:
+        try:
+            ts = datetime.now(timezone.utc).isoformat()
+            dynamodb_client.update_item(
+                TableName=DB_TABLE,
+                Key={'jobId': {'S': job_id}},
+                UpdateExpression="SET #ao = :ao, #at = :at",
+                ExpressionAttributeNames={'#ao': 'analysisOutputJsonStr', '#at': 'analysisTimestamp'},
+                ExpressionAttributeValues={
+                    ':ao': {'S': json.dumps(aggregated_result)},
+                    ':at': {'S': ts}
+                }
+            )
+            print(f"[aggregate-analysis] Persisted aggregated analysis for job {job_id}")
+        except Exception as e:
+            print(f"[aggregate-analysis] Error persisting to DynamoDB: {e}")
+            return {'error': f'Failed to persist: {str(e)}'}
+    
+    return {
+        'status': 'success',
+        'message': 'Analysis aggregated successfully',
+        'analysisOutput': aggregated_result
+    }

--- a/cdk/lambda-functions/aggregate-detection/index.py
+++ b/cdk/lambda-functions/aggregate-detection/index.py
@@ -1,0 +1,133 @@
+import json
+import boto3
+import os
+from datetime import datetime, timezone
+
+dynamodb_client = boto3.client('dynamodb')
+s3_client = boto3.client('s3')
+
+DB_TABLE = os.environ.get('JOBS_TABLE_NAME')
+TRACE_BUCKET = os.environ.get('TRACE_BUCKET')
+
+
+def aggregate_detection_results(chunk_results: list) -> dict:
+    """Merge multiple chunk detection results into a single result"""
+    print(f"[aggregate-detection] Aggregating {len(chunk_results)} chunk results")
+    
+    # Log any errors
+    error_chunks = [r for r in chunk_results if 'error' in r]
+    if error_chunks:
+        print(f"[aggregate-detection] WARNING: {len(error_chunks)} chunks had errors:")
+        for err_chunk in error_chunks:
+            print(f"  - Chunk {err_chunk.get('chunkId', '?')}: {err_chunk.get('error', 'Unknown error')}")
+    
+    # Filter out error results
+    valid_results = [r for r in chunk_results if 'error' not in r]
+    if not valid_results:
+        return {'error': 'All chunks failed to detect', 'failed_chunks': len(chunk_results)}
+    
+    print(f"[aggregate-detection] {len(valid_results)} valid results")
+    
+    aggregated = {
+        "impairments": [],
+        "narrative": ""
+    }
+    
+    # Combine impairments (deduplicate by impairment_id)
+    seen_impairments = {}
+    for result in valid_results:
+        for imp in result.get("impairments", []):
+            imp_id = imp.get("impairment_id", "")
+            if imp_id in seen_impairments:
+                # Merge evidence and scoring factors
+                existing = seen_impairments[imp_id]
+                existing["evidence"] = list(set(existing.get("evidence", []) + imp.get("evidence", [])))
+                existing["scoring_factors"].update(imp.get("scoring_factors", {}))
+            else:
+                seen_impairments[imp_id] = imp
+    
+    aggregated["impairments"] = list(seen_impairments.values())
+    
+    # Combine narratives
+    narratives = [r.get("narrative", "") for r in valid_results if r.get("narrative")]
+    if narratives:
+        aggregated["narrative"] = "\n\n".join(narratives)
+    
+    print(f"[aggregate-detection] Aggregated: {len(aggregated['impairments'])} impairments")
+    
+    return aggregated
+
+
+def lambda_handler(event, context):
+    print(f"[aggregate-detection] Received event: {json.dumps(event)}")
+    
+    job_id = event.get('jobId')
+    chunk_results = event.get('chunkResults', [])
+    classification = event.get('classification', {})
+    
+    if not job_id:
+        return {'error': 'Missing jobId'}
+    
+    if not chunk_results:
+        return {'error': 'No chunk results to aggregate'}
+    
+    # Update status to DETECTING
+    if DB_TABLE:
+        try:
+            from datetime import datetime, timezone
+            now = datetime.now(timezone.utc).isoformat()
+            dynamodb_client.update_item(
+                TableName=DB_TABLE,
+                Key={'jobId': {'S': job_id}},
+                UpdateExpression='SET #status = :s, lastUpdated = :t',
+                ExpressionAttributeNames={'#status': 'status'},
+                ExpressionAttributeValues={':s': {'S': 'DETECTING'}, ':t': {'S': now}}
+            )
+            print(f"[aggregate-detection] Updated status to DETECTING for job {job_id}")
+        except Exception as e:
+            print(f"[aggregate-detection] WARNING: Failed to update status: {e}")
+    
+    # Aggregate results
+    aggregated_result = aggregate_detection_results(chunk_results)
+    
+    if 'error' in aggregated_result:
+        return aggregated_result
+    
+    # Store trace in S3
+    if TRACE_BUCKET:
+        try:
+            trace_key = f"detection-traces/{job_id}/aggregated-detection.json"
+            s3_client.put_object(
+                Bucket=TRACE_BUCKET,
+                Key=trace_key,
+                Body=json.dumps(aggregated_result, indent=2),
+                ContentType='application/json'
+            )
+            print(f"[aggregate-detection] Stored trace at s3://{TRACE_BUCKET}/{trace_key}")
+        except Exception as e:
+            print(f"[aggregate-detection] Error storing trace: {e}")
+    
+    # Persist to DynamoDB
+    if DB_TABLE:
+        try:
+            ts = datetime.now(timezone.utc).isoformat()
+            dynamodb_client.update_item(
+                TableName=DB_TABLE,
+                Key={'jobId': {'S': job_id}},
+                UpdateExpression="SET #ad = :ad, #dt = :dt",
+                ExpressionAttributeNames={'#ad': 'analysisDetectionJsonStr', '#dt': 'detectionTimestamp'},
+                ExpressionAttributeValues={
+                    ':ad': {'S': json.dumps(aggregated_result)},
+                    ':dt': {'S': ts}
+                }
+            )
+            print(f"[aggregate-detection] Persisted aggregated detection for job {job_id}")
+        except Exception as e:
+            print(f"[aggregate-detection] Error persisting to DynamoDB: {e}")
+            return {'error': f'Failed to persist: {str(e)}'}
+    
+    return {
+        'status': 'success',
+        'message': 'Detection aggregated successfully',
+        'analysisDetection': aggregated_result
+    }

--- a/cdk/lambda-functions/analyze-chunk/index.py
+++ b/cdk/lambda-functions/analyze-chunk/index.py
@@ -1,0 +1,175 @@
+import json
+import boto3
+import os
+from botocore.config import Config
+
+# Configure retry settings for Bedrock client
+bedrock_retry_config = Config(
+    retries={'max_attempts': 10, 'mode': 'adaptive'},
+    max_pool_connections=50
+)
+
+bedrock_runtime = boto3.client(service_name='bedrock-runtime', config=bedrock_retry_config)
+s3_client = boto3.client('s3')
+dynamodb_client = boto3.client('dynamodb')
+
+EXTRACTION_BUCKET = os.environ.get('EXTRACTION_BUCKET')
+DB_TABLE = os.environ.get('JOBS_TABLE_NAME')
+MODEL_ID = os.environ.get('BEDROCK_ANALYSIS_MODEL_ID', 'us.anthropic.claude-3-7-sonnet-20250219-v1:0')
+
+ANALYSIS_OUTPUT_SCHEMA = {
+    "overall_summary": "string",
+    "identified_risks": [
+        {"risk_description": "string", "severity": "string", "page_references": ["string"]}
+    ],
+    "discrepancies": [
+        {"discrepancy_description": "string", "details": "string", "page_references": ["string"]}
+    ],
+    "medical_timeline": "string",
+    "property_assessment": "string",
+    "final_recommendation": "string",
+    "missing_information": [
+        {"item_description": "string", "notes": "string"}
+    ],
+    "confidence_score": "float"
+}
+
+def get_language_instruction(language: str) -> str:
+    language_map = {
+        'en-US': 'Respond in English.',
+        'zh-CN': 'Respond in Simplified Chinese (简体中文).',
+        'ja-JP': 'Respond in Japanese (日本語).',
+        'es-ES': 'Respond in Spanish (Español).',
+        'fr-FR': 'Respond in French (Français).',
+        'fr-CA': 'Respond in Canadian French (Français canadien).',
+        'de-DE': 'Respond in German (Deutsch).',
+        'it-IT': 'Respond in Italian (Italiano).',
+    }
+    return language_map.get(language, 'Respond in English.')
+
+
+def lambda_handler(event, context):
+    print(f"[analyze-chunk] Received event: {json.dumps(event)}")
+    
+    chunk_id = event.get('chunkId')
+    chunk_s3_key = event.get('chunkS3Key')
+    job_id = event.get('jobId')
+    total_chunks = event.get('totalChunks', 1)
+    
+    if not chunk_s3_key:
+        return {'error': 'Missing chunkS3Key'}
+    
+    # Read user language preference from DynamoDB
+    language = 'en-US'
+    if job_id and DB_TABLE:
+        try:
+            resp = dynamodb_client.get_item(
+                TableName=DB_TABLE,
+                Key={'jobId': {'S': job_id}},
+                ProjectionExpression='userLanguage'
+            )
+            item = resp.get('Item', {})
+            language = (item.get('userLanguage') or {}).get('S') or 'en-US'
+            print(f"[analyze-chunk] User language for job {job_id}: {language}")
+        except Exception as e:
+            print(f"[analyze-chunk] Error reading userLanguage: {e}")
+    
+    # --- 1) Fetch chunk data from S3 ---
+    print(f"[analyze-chunk] Fetching chunk {chunk_id} from S3: {chunk_s3_key}")
+    try:
+        obj = s3_client.get_object(Bucket=EXTRACTION_BUCKET, Key=chunk_s3_key)
+        chunk_data = json.loads(obj['Body'].read().decode('utf-8'))
+    except Exception as e:
+        print(f"[analyze-chunk] Error fetching chunk: {e}")
+        return {'error': f'Failed to fetch chunk: {str(e)}'}
+    
+    # --- 2) Build analysis prompt ---
+    consolidated = json.dumps(chunk_data, indent=2)
+    print(f"[analyze-chunk] Chunk {chunk_id} data size: {len(consolidated)} chars")
+    
+    language_instruction = get_language_instruction(language)
+    
+    chunk_context = ""
+    if total_chunks > 1:
+        chunk_context = f"\n\nNote: This is chunk {chunk_id + 1} of {total_chunks}. Analyze this subset of the document."
+    
+    analysis_prompt_text = f"""You are an expert insurance underwriter tasked with analyzing extracted document information.
+        The following data was extracted from an insurance document:
+        <extracted_data>
+        {consolidated}
+        </extracted_data>
+        {chunk_context}
+
+        Please perform a comprehensive analysis. Your goal is to:
+        1. Provide an 'overall_summary' of the document content and its purpose based on the extracted data.
+        2. Identify key risks in 'identified_risks'. For each risk, include 'risk_description', 'severity' (Low, Medium, or High), and 'page_references' (list of strings, e.g., ["1", "3-5"], use ["N/A"] if not applicable).
+        3. Identify any discrepancies or inconsistencies in 'discrepancies'. For each, include 'discrepancy_description', 'details' (provide specific details of the discrepancy), and 'page_references' (list of strings, e.g., ["2", "10"], use ["N/A"] if not applicable).
+        4. Provide a 'medical_timeline' (string, use Markdown for formatting) if the document is medical-related. If not applicable, provide an empty string or "N/A".
+        5. Provide a 'property_assessment' (string, use Markdown for formatting) if the document is property-related (e.g., commercial property application). If not applicable, provide an empty string or "N/A".
+        6. Formulate a 'final_recommendation' (string, use Markdown for formatting) for the underwriter based on your analysis (e.g., approve, decline with reasons, request more info).
+        7. List any critical missing information in 'missing_information'. For each, include 'item_description' and 'notes'.
+        8. If you can estimate a 'confidence_score' (0.0 to 1.0) for your overall analysis based on the quality and completeness of the provided extracted data, include it. Otherwise, you can omit it or use a default like 0.75.
+        
+        Structure your response as a single JSON object matching the following schema precisely. Do not include any explanations or text outside this JSON structure:
+        {json.dumps(ANALYSIS_OUTPUT_SCHEMA, indent=2)}
+        
+        Important Guidelines:
+        - Adhere strictly to the JSON schema provided for the output.
+        - If a section like 'identified_risks', 'discrepancies', or 'missing_information' has no items, provide an empty list ([]) for that key.
+        - For 'page_references', if the source extracted data does not contain explicit page numbers associated with the information, use ["N/A"].
+        - If you can estimate a 'confidence_score' (0.0 to 1.0) for your overall analysis based on the quality and completeness of the provided extracted data, include it. Otherwise, you can omit it or use a default like 0.75.
+        
+        IMPORTANT: {language_instruction} All text content in the JSON (summaries, descriptions, recommendations) must be in this language.
+        
+        Return ONLY the JSON object.
+        """
+    
+    # --- 3) Call Bedrock ---
+    print(f"[analyze-chunk] Calling Bedrock for chunk {chunk_id}")
+    try:
+        response = bedrock_runtime.converse(
+            modelId=MODEL_ID,
+            messages=[{"role": "user", "content": [{"text": analysis_prompt_text}]}],
+            inferenceConfig={"maxTokens": 16384, "temperature": 0.05}
+        )
+        print(f"[analyze-chunk] Bedrock response received for chunk {chunk_id}")
+    except Exception as e:
+        print(f"[analyze-chunk] Bedrock error: {e}")
+        return {'error': f'Bedrock error: {str(e)}'}
+    
+    # --- 4) Parse response ---
+    out = response.get('output', {}).get('message', {}).get('content', [])
+    text_block = out[0] if out and isinstance(out[0], dict) else {}
+    text = text_block.get('text', '')
+    
+    print(f"[analyze-chunk] Bedrock response text length: {len(text)} chars")
+    
+    if not text or not text.strip():
+        print(f"[analyze-chunk] ERROR: Empty response from Bedrock")
+        return {'error': 'Empty response from Bedrock', 'chunkId': chunk_id}
+    
+    # Try to extract JSON from markdown code blocks if present
+    if '```json' in text:
+        try:
+            json_start = text.index('```json') + 7
+            json_end = text.index('```', json_start)
+            text = text[json_start:json_end].strip()
+        except:
+            pass
+    elif '```' in text:
+        try:
+            json_start = text.index('```') + 3
+            json_end = text.index('```', json_start)
+            text = text[json_start:json_end].strip()
+        except:
+            pass
+    
+    try:
+        analysis_result = json.loads(text)
+        analysis_result['chunkId'] = chunk_id
+        print(f"[analyze-chunk] Successfully parsed analysis for chunk {chunk_id}")
+        return analysis_result
+    except Exception as e:
+        print(f"[analyze-chunk] Error parsing Bedrock response: {e}")
+        print(f"[analyze-chunk] Response text preview: {text[:500]}")
+        return {'error': f'Failed to parse response: {str(e)}', 'chunkId': chunk_id, 'raw_text': text[:500]}

--- a/cdk/lambda-functions/chunk-data/index.py
+++ b/cdk/lambda-functions/chunk-data/index.py
@@ -1,0 +1,142 @@
+import json
+import boto3
+import os
+from datetime import datetime, timezone
+
+s3_client = boto3.client('s3')
+dynamodb_client = boto3.client('dynamodb')
+
+EXTRACTION_BUCKET = os.environ.get('EXTRACTION_BUCKET')
+DB_TABLE = os.environ.get('JOBS_TABLE_NAME')
+
+def chunk_extracted_data(extracted_data: dict, max_chunk_size: int = 500000) -> list:
+    """
+    Split extracted data into chunks that fit within token limits.
+    Returns list of chunk metadata with S3 keys.
+    """
+    chunks = []
+    current_chunk = {}
+    current_size = 0
+    
+    for doc_type, pages in extracted_data.items():
+        doc_json = json.dumps({doc_type: pages})
+        doc_size = len(doc_json)
+        
+        # If adding this doc exceeds limit, save current chunk and start new one
+        if current_size + doc_size > max_chunk_size and current_chunk:
+            chunks.append(current_chunk)
+            current_chunk = {}
+            current_size = 0
+        
+        # If single doc type exceeds limit, split its pages
+        if doc_size > max_chunk_size and isinstance(pages, list):
+            # Calculate pages per chunk
+            pages_json_size = len(json.dumps(pages))
+            pages_per_chunk = max(1, int(len(pages) * (max_chunk_size / pages_json_size)))
+            
+            for i in range(0, len(pages), pages_per_chunk):
+                page_subset = pages[i:i + pages_per_chunk]
+                chunks.append({doc_type: page_subset})
+        else:
+            current_chunk[doc_type] = pages
+            current_size += doc_size
+    
+    # Add remaining chunk
+    if current_chunk:
+        chunks.append(current_chunk)
+    
+    return chunks
+
+
+def lambda_handler(event, context):
+    print(f"[chunk-data] Received event: {json.dumps(event)}")
+    
+    job_id = event.get('classification', {}).get('jobId')
+    chunk_type = event.get('chunkType', 'analysis')  # 'analysis' or 'detection'
+    
+    if not job_id:
+        return {'error': 'Missing jobId'}
+    
+    # --- 1) Fetch & merge all extraction chunks from S3 ---
+    print("[chunk-data] Merging extractionResults from S3")
+    merged_data = {}
+    raw_results = event.get('extractionResults', [])
+    
+    for idx, chunk_meta in enumerate(raw_results):
+        key = chunk_meta.get('chunkS3Key')
+        if not key:
+            continue
+        
+        try:
+            obj = s3_client.get_object(Bucket=EXTRACTION_BUCKET, Key=key)
+            chunk_data = json.loads(obj['Body'].read().decode('utf-8'))
+            
+            for subdoc, pages_list in chunk_data.items():
+                merged_data.setdefault(subdoc, []).extend(pages_list or [])
+        except Exception as e:
+            print(f"[chunk-data] Error fetching chunk {idx}: {e}")
+            continue
+    
+    print(f"[chunk-data] Merged data keys: {list(merged_data.keys())}")
+    
+    # --- 2) Store merged extracted data in S3 and write to DynamoDB (only for analysis) ---
+    if chunk_type == 'analysis' and job_id and DB_TABLE:
+        try:
+            ts = datetime.now(timezone.utc).isoformat()
+            document_type = event.get('classification', {}).get('classification', 'Unknown')
+            
+            # Store merged extracted data in S3
+            extracted_data_key = f"{job_id}/merged/merged.json"
+            s3_client.put_object(
+                Bucket=EXTRACTION_BUCKET,
+                Key=extracted_data_key,
+                Body=json.dumps(merged_data),
+                ContentType='application/json'
+            )
+            s3_path = f"s3://{EXTRACTION_BUCKET}/{extracted_data_key}"
+            print(f"[chunk-data] Stored merged extracted data in S3: {s3_path}")
+            
+            # Write S3 path to DynamoDB
+            dynamodb_client.update_item(
+                TableName=DB_TABLE,
+                Key={'jobId': {'S': job_id}},
+                UpdateExpression="SET #dt = :dt, #ed = :ed, #et = :et",
+                ExpressionAttributeNames={'#dt': 'documentType', '#ed': 'extractedDataJsonStr', '#et': 'extractionTimestamp'},
+                ExpressionAttributeValues={
+                    ':dt': {'S': document_type},
+                    ':ed': {'S': s3_path},
+                    ':et': {'S': ts}
+                }
+            )
+            print(f"[chunk-data] Persisted S3 path to extractedDataJsonStr for job {job_id}")
+        except Exception as e:
+            print(f"[chunk-data] Error storing extractedDataJsonStr: {e}")
+    
+    # --- 3) Chunk the merged data ---
+    chunks = chunk_extracted_data(merged_data)
+    print(f"[chunk-data] Created {len(chunks)} chunks for {chunk_type}")
+    
+    # --- 4) Store each chunk in S3 and return metadata ---
+    chunk_metadata = []
+    for i, chunk in enumerate(chunks):
+        chunk_key = f"{job_id}/{chunk_type}-chunks/chunk-{i}.json"
+        s3_client.put_object(
+            Bucket=EXTRACTION_BUCKET,
+            Key=chunk_key,
+            Body=json.dumps(chunk),
+            ContentType='application/json'
+        )
+        
+        chunk_metadata.append({
+            'chunkId': i,
+            'chunkS3Key': chunk_key,
+            'documentTypes': list(chunk.keys())
+        })
+        print(f"[chunk-data] Stored chunk {i} at s3://{EXTRACTION_BUCKET}/{chunk_key}")
+    
+    return {
+        'jobId': job_id,
+        'totalChunks': len(chunks),
+        'chunks': chunk_metadata,
+        'chunkType': chunk_type
+    }

--- a/cdk/lambda-functions/detect-chunk/index.py
+++ b/cdk/lambda-functions/detect-chunk/index.py
@@ -1,0 +1,226 @@
+import json
+import boto3
+import os
+from strands import Agent, tool
+from strands.models import BedrockModel
+from botocore.config import Config as BotoConfig
+
+s3_client = boto3.client('s3')
+kb_runtime = boto3.client('bedrock-agent-runtime')
+dynamodb_client = boto3.client('dynamodb')
+
+EXTRACTION_BUCKET = os.environ.get('EXTRACTION_BUCKET')
+KNOWLEDGE_BASE_ID = os.environ.get('KNOWLEDGE_BASE_ID')
+DB_TABLE = os.environ.get('JOBS_TABLE_NAME')
+MODEL_ID = os.environ.get('BEDROCK_DETECTION_MODEL_ID', 'global.anthropic.claude-haiku-4-5-20251001-v1:0')
+
+
+def get_language_instruction(language: str) -> str:
+    language_map = {
+        'en-US': 'Respond in English.',
+        'zh-CN': 'Respond in Simplified Chinese (简体中文).',
+        'ja-JP': 'Respond in Japanese (日本語).',
+        'es-ES': 'Respond in Spanish (Español).',
+        'fr-FR': 'Respond in French (Français).',
+        'fr-CA': 'Respond in Canadian French (Français canadien).',
+        'de-DE': 'Respond in German (Deutsch).',
+        'it-IT': 'Respond in Italian (Italiano).',
+    }
+    return language_map.get(language, 'Respond in English.')
+
+
+def build_agent(insurance_type: str, language: str):
+    """Build Strands Agent with full logic from detect-impairments"""
+    language_instruction = get_language_instruction(language)
+
+    @tool
+    def scratch_fixed(action: str, key: str, value=None, agent=None):
+        """Tool for temporary storage during agent execution"""
+        scratch_data = agent.state.get('scratch_pad') or {}
+        if action == 'append':
+            if key not in scratch_data:
+                scratch_data[key] = []
+            scratch_data[key].append(value)
+        elif action == 'set':
+            scratch_data[key] = value
+        elif action == 'get':
+            return scratch_data.get(key)
+        agent.state.set('scratch_pad', scratch_data)
+        return 'ok'
+
+    @tool
+    def kb_search(canonical_term: str):
+        """Return markdown for the top KB hit from Bedrock Knowledge Base"""
+        print(f"[kb_search] Searching for {canonical_term}")
+        if not KNOWLEDGE_BASE_ID:
+            return "Knowledge base not configured."
+        try:
+            resp = kb_runtime.retrieve(
+                knowledgeBaseId=KNOWLEDGE_BASE_ID,
+                retrievalQuery={'text': canonical_term},
+                retrievalConfiguration={'vectorSearchConfiguration': {'numberOfResults': 1}}
+            )
+            results = resp.get('retrievalResults') or []
+            if not results:
+                return "No matching documents found."
+            content = results[0].get('content').get('text') or {}
+            location = results[0].get('location').get('s3Location').get('uri') or {}
+            print(f"[kb_search] Found {canonical_term} in {location}")
+            return f"""
+            knowledgebase_location: {location}
+            text_content: {content}
+            """
+        except Exception as e:
+            return f"KB retrieval error: {e}"
+
+    LIFE_PROMPT = """You are a senior life insurance underwriter. Your job is to analyze the data stream for an application and identify impairments, 
+scoring factors (based on the knowledge base), and evidences for those impairments. 
+1. Scan the extracted data for impairment evidence and write out an initial list of impairments.
+Then for each impairment in your scratch pad, do the following:
+2. Call kb_search() once and treat the markdown returned as authoritative. Make sure to record the page numbers where you found evidence for the impairment and the knowledgebase_location for the impairment to be used in the final JSON output.
+3. Use the ratings tables in the returned markdown to determine a list of "scoring factors" are required to completely score that impairment and write them out. 
+4. If the impairment is not found in the knowledge base, omit it from the final JSON output.
+5. Search through the XML feeds to consolidate the values for each scoring factor, and the list of evidence for that impairment. 
+6. Write out the scoring factors and evidence for that impairment.
+
+Repeat this process for each impairment you find. Deduplicate any impairment that is found in multiple XML feeds into one listng. 
+
+Once you have completed this process for all impairments, return a well-structured JSON response like the following:
+
+```json  
+{ 
+   "impairments": [
+     {
+       "impairment_id": "diabetes",
+       "scoring_factors": {"A1C": 8.2, "Neuropathy": true},
+       "evidence": ["Rx: insulin … (Page 3,4)", "Lab: A1C 8.2 % (Page 1)"],
+       "discrepancies": ["answered no to Diabetes Questionnaire but evidence of diabetes"],
+       "knowledgebase_location": "s3://...",
+     }
+   ],
+   "narrative": "Agent Analysis: ..."
+}
+```
+
+IMPORTANT: """ + language_instruction + """ All text content in the JSON must be in this language."""
+
+    PC_PROMPT = """You are a senior property and casualty insurance underwriter. Analyze the extracted data for risk drivers and underwriting concerns relevant to P&C (not life).
+
+Your goals:
+1. Identify a list of P&C risk drivers (call them "impairments" for consistency).
+2. For each risk driver, list the specific "scoring_factors" you would evaluate for P&C.
+3. Gather concise "evidence" strings from the extracted data.
+
+Important:
+- Do NOT use any life underwriting manual or knowledge base content. There is no KB available for P&C. Do not call any KB tools.
+
+Return a single JSON object in this format:
+```json
+{
+  "impairments": [
+    {
+      "impairment_id": "fire_risk",
+      "scoring_factors": {"construction": "masonry noncombustible", "sprinklered": true},
+      "evidence": ["BCEGS class 3 noted on application (Page 2)"]
+    }
+  ],
+  "narrative": "Brief P&C-focused summary of key risks."
+}
+```
+
+IMPORTANT: """ + language_instruction + """ All text content in the JSON must be in this language."""
+
+    retrying_cfg = BotoConfig(retries={"mode": "adaptive", "max_attempts": 12})
+    model = BedrockModel(model_id=MODEL_ID, boto_client_config=retrying_cfg)
+
+    if (insurance_type or "").lower() == "life":
+        return Agent(system_prompt=LIFE_PROMPT, tools=[kb_search, scratch_fixed], model=model)
+    else:
+        return Agent(system_prompt=PC_PROMPT, tools=[scratch_fixed], model=model)
+
+
+def lambda_handler(event, context):
+    print(f"[detect-chunk] Received event: {json.dumps(event)}")
+    
+    chunk_id = event.get('chunkId')
+    chunk_s3_key = event.get('chunkS3Key')
+    job_id = event.get('jobId')
+    insurance_type = event.get('insuranceType', 'life_health')
+    
+    if not chunk_s3_key:
+        return {'error': 'Missing chunkS3Key'}
+    
+    # Read user language preference from DynamoDB
+    language = 'en-US'
+    if job_id and DB_TABLE:
+        try:
+            resp = dynamodb_client.get_item(
+                TableName=DB_TABLE,
+                Key={'jobId': {'S': job_id}},
+                ProjectionExpression='userLanguage'
+            )
+            item = resp.get('Item', {})
+            language = (item.get('userLanguage') or {}).get('S') or 'en-US'
+            print(f"[detect-chunk] User language for job {job_id}: {language}")
+        except Exception as e:
+            print(f"[detect-chunk] Error reading userLanguage: {e}")
+    
+    if not chunk_s3_key:
+        return {'error': 'Missing chunkS3Key'}
+    
+    # Fetch chunk from S3
+    print(f"[detect-chunk] Fetching chunk {chunk_id} from S3")
+    try:
+        obj = s3_client.get_object(Bucket=EXTRACTION_BUCKET, Key=chunk_s3_key)
+        chunk_data = json.loads(obj['Body'].read().decode('utf-8'))
+    except Exception as e:
+        print(f"[detect-chunk] Error fetching chunk: {e}")
+        return {'error': f'Failed to fetch chunk: {str(e)}'}
+    
+    # Build agent and run detection
+    print(f"[detect-chunk] Running Strands agent for chunk {chunk_id}")
+    agent = build_agent(insurance_type, language)
+    
+    message_str = json.dumps(chunk_data, ensure_ascii=False)
+    print(f"[detect-chunk] Chunk {chunk_id} data size: {len(message_str)} bytes")
+    
+    try:
+        result = agent(message_str)
+        print(f"[detect-chunk] Agent completed for chunk {chunk_id}")
+        print(f"[detect-chunk] Agent result type: {type(result)}")
+        
+        # Strands Agent returns AgentResult object, get the text content
+        if hasattr(result, 'content'):
+            result_text = result.content
+        elif hasattr(result, 'text'):
+            result_text = result.text
+        else:
+            result_text = str(result)
+        
+        print(f"[detect-chunk] Result text length: {len(result_text)} chars")
+        
+        # Try to extract JSON from markdown code blocks if present
+        if '```json' in result_text:
+            try:
+                json_start = result_text.index('```json') + 7
+                json_end = result_text.index('```', json_start)
+                result_text = result_text[json_start:json_end].strip()
+            except:
+                pass
+        elif '```' in result_text:
+            try:
+                json_start = result_text.index('```') + 3
+                json_end = result_text.index('```', json_start)
+                result_text = result_text[json_start:json_end].strip()
+            except:
+                pass
+        
+        # Parse result
+        parsed_result = json.loads(result_text)
+        parsed_result['chunkId'] = chunk_id
+        return parsed_result
+    except Exception as e:
+        print(f"[detect-chunk] Error running agent: {e}")
+        import traceback
+        traceback.print_exc()
+        return {'error': f'Agent error: {str(e)}', 'chunkId': chunk_id}


### PR DESCRIPTION
Implemented parallel chunking architecture to handle large documents that exceeded Bedrock’s 200K token context for claude models and DynamoDB’s 400KB limit. Refactored and created new analyze (UW) and detect impairments lambdas to handle chunking of data and later aggregating in step functions. All content seems to be analyzed without missing pages while staying within token limits of LLM model context